### PR TITLE
revert: "chore: build protocol image for arm64 platform"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,6 +75,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Reverts otimlabs/otim-protocol#94

Will be reapplied once a strategy is developed that reduces image build times with it set (build times are currently taking 20+ minutes with the `arm64` build enabled)