### PR TITLE
fix: adjust cross-rate price feed tests to ensure fresh price round data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,3 @@ jobs:
       - uses: go-semantic-release/action@2e9dc4247a6004f8377781bef4cb9dad273a741f # v1.24.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          force-bump-patch-version: true # ensure patch version updates trigger releases

--- a/test/infrastructure/CrossRatePriceFeed.t.sol
+++ b/test/infrastructure/CrossRatePriceFeed.t.sol
@@ -38,9 +38,11 @@ contract CrossRatePriceFeedTest is Test {
         (,,, uint256 numeratorUpdatedAt,) = usdcUsdFeed.latestRoundData();
         (,,, uint256 denominatorUpdatedAt,) = ethUsdFeed.latestRoundData();
 
-        // Warp to the later of the two update times to ensure both are fresh
-        uint256 latestUpdate = numeratorUpdatedAt > denominatorUpdatedAt ? numeratorUpdatedAt : denominatorUpdatedAt;
-        vm.warp(latestUpdate);
+        // Warp to just before the earliest feed expiration
+        uint256 numeratorExpiry = numeratorUpdatedAt + USDC_USD_HEARTBEAT;
+        uint256 denominatorExpiry = denominatorUpdatedAt + ETH_USD_HEARTBEAT;
+        uint256 minExpiry = numeratorExpiry < denominatorExpiry ? numeratorExpiry : denominatorExpiry;
+        vm.warp(minExpiry - 1);
     }
 
     /// @notice test constructor reverts with zero numerator feed


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please provide the details below to help with code reviews.
-->

## Motivation

<!--
Add your GitHub issue ID using the format "#123". This can automatically update
the issue status using GitHub's closing keywords. Examples of closing keywords:
- Closing: closes, fixes, resolves
- Non-closing: ref, references, related to, see

For PRs without a GitHub issue, briefly explain why you're making this change.
Keep it concise - if the explanation becomes lengthy, consider creating a GitHub issue.
-->

Resolve cross-rate price feed test failures due to stale network price data ([example](https://github.com/otimlabs/otim-protocol/actions/runs/21478621285))

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

* revise the warp time calculation based on price-feed numerator/denominator heartbeats
* also remove the `force-bump-patch-version` property from the semantic release workflow to avoid creating empty commit releases (see for [details](https://github.com/go-semantic-release/action?tab=readme-ov-file#arguments)) 

## Reviewer Checklist

<!--
## Type of change

You can add a semantic prefix to your PR title (e.g., "fix: resolve payment issue")
to automatically apply appropriate labels. Alternatively, labels can be manually added in the GitHub interface.

Supported prefixes:
- feat: (new feature)
- fix: (bug fix)
- chore: (maintenance tasks)
- test: (test additions/changes)
- docs: (documentation changes)
- style: (formatting changes)
- breaking-change: (breaks existing functionality)
- hotfix: (emergency production fixes)
- revert: (reverting previous changes)

## Automated Checklist

Code quality checks are increasingly handled by pre-commit hooks and CI.
Ensure you have pre-commit installed. Many of these items will be automatically
verified, but please review the below checklist for any which may require human judgment.
-->

- [x] tests have been added to validate the change
- [x] code has been commented, particularly in hard-to-understand areas
- [ ] corresponding documentation updates have been made
